### PR TITLE
fix: use full screen for image in Recipe homescreen

### DIFF
--- a/src/pages/CRUD/RecipesHome.jsx
+++ b/src/pages/CRUD/RecipesHome.jsx
@@ -60,8 +60,8 @@ const RecipesHome = (props) => {
                                             )}
                                             {recipe.image && (
                                                 <img
-                                                    alt="user"
-                                                    className="block h-40 w-auto rounded-2xl  "
+                                                    alt="recipe image"
+                                                    className="block h-40 w-full object-cover rounded-2xl"
                                                     src={recipe.image}
                                                 />
                                             )}


### PR DESCRIPTION
## Summary

Use full width and Object fit for the images, to keep the same UI for all the recipes.

Left is the original css, and the right image has css change :) 

<img width="607" alt="image" src="https://user-images.githubusercontent.com/3399429/210579213-5cfc89fc-45e3-441f-b444-7a2e5205088a.png">
